### PR TITLE
Fix offset_encoding being non-optional in nightly neovim

### DIFF
--- a/lua/nvim-treesitter/nt-cpp-tools/internal.lua
+++ b/lua/nvim-treesitter/nt-cpp-tools/internal.lua
@@ -34,7 +34,7 @@ local function add_text_edit(text, start_row, start_col)
         },
         newText = text
     })
-    vim.lsp.util.apply_text_edits(edit, 0)
+    vim.lsp.util.apply_text_edits(edit, 0, 'utf-16')
 end
 
 local function t2s(txt)


### PR DESCRIPTION
Small fix for https://github.com/neovim/neovim/issues/14090#issuecomment-1012005684, otherwise this plugins is failing on nightly neovim