### PR TITLE
Fix default buffer being 0

### DIFF
--- a/lua/nt-cpp-tools/internal.lua
+++ b/lua/nt-cpp-tools/internal.lua
@@ -7,16 +7,18 @@ local util = require("nt-cpp-tools.util")
 
 local M = {}
 
-local function get_node_text(node)
+local function get_node_text(node, bufnr)
     if not node then
         return {}
     end
 
-    local txtStr = vim.treesitter.get_node_text(node, 0)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    local txtStr = vim.treesitter.get_node_text(node, bufnr)
     local txt = {}
 
     for str in string.gmatch(txtStr, "([^\n]+)") do
-      table.insert(txt, str)
+        table.insert(txt, str)
     end
     return txt
 end


### PR DESCRIPTION
I have made a stupid oversight... I was passing in 0 as the buffer when it was not specified. That means it works well when there is only one buffer but breaks down when your current buffer is not buffer 0. I've made the fix to this. Sorry if I caused any inconvenience. 