### PR TITLE
add 'noexcept' for move constructor and move assignment in rule of 5

### DIFF
--- a/lua/nt-cpp-tools/internal.lua
+++ b/lua/nt-cpp-tools/internal.lua
@@ -475,13 +475,13 @@ function M.rule_of_5(limit_at_3, range_start, range_end)
     if not limit_at_3 then
         if not checkers.move_assignment then
             util.add_text_edit(newLine, entry_location.start_row, 0)
-            local txt = class_name .. '& operator=(' .. class_name .. '&&);'
+            local txt = class_name .. '& operator=(' .. class_name .. '&&) noexcept;'
             add_txt_below_existing_def(txt)
         end
 
         if not checkers.move_constructor then
             util.add_text_edit(newLine, entry_location.start_row, 0)
-            local txt = class_name .. '(const ' .. class_name .. '&&);'
+            local txt = class_name .. '(const ' .. class_name .. '&&) noexcept;'
             add_txt_below_existing_def(txt)
         end
     end


### PR DESCRIPTION
Hello Badhi,

It's a great plugin and simplify my C++ development in neovim.

Here I suggest that the generated move constructor and move assignment should have a default `noexcept`.

A throwing move violates most people’s reasonable assumptions, it's better to mark `noexcept` in these functions.

References for this PR are as follows
- [Cpp Core Guidelines: C66. make move operations noexcept](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c66-make-move-operations-noexcept)
- [clang-tidy: performance-noexcept-move-constructor](https://clang.llvm.org/extra/clang-tidy/checks/performance/noexcept-move-constructor.html)

I am using `clang-tidy` in my projects, and without `noexcept` warnings are throwed. So I create this PR.

Thanks